### PR TITLE
chore: make request only if has valid tokens

### DIFF
--- a/src/main/decorators/spotify-authorize-http-client-decorator/spotify-authorize-http-client-decorator.ts
+++ b/src/main/decorators/spotify-authorize-http-client-decorator/spotify-authorize-http-client-decorator.ts
@@ -32,6 +32,9 @@ export class SpotifyAuthorizeHttpClientDecorator<T = unknown>
 
       refresh_token = new_refresh_token;
 
+      if (!token_type || !access_token)
+        throw new Error("Invalid token type and access token");
+
       Authorization = `${token_type} ${access_token}`;
 
       await this.storageAdapter.set("refresh_token", refresh_token);

--- a/src/presentation/pages/home/helpers.ts
+++ b/src/presentation/pages/home/helpers.ts
@@ -32,14 +32,14 @@ export function useHomeHelpers({
     if (code) {
       remoteLoadCurrentUserInfo.load().then((response) => {
         setUserInfo(response);
-      });
 
-      remoteGetMyPlaylists.load().then((remotePlaylists) => {
-        setPlaylists(remotePlaylists);
-      });
+        remoteGetMyPlaylists.load().then((remotePlaylists) => {
+          setPlaylists(remotePlaylists);
+        });
 
-      remoteBrowseFeaturedPlaylists.load().then((remoteFeaturedPlaylists) => {
-        setFeaturedPlaylists(remoteFeaturedPlaylists);
+        remoteBrowseFeaturedPlaylists.load().then((remoteFeaturedPlaylists) => {
+          setFeaturedPlaylists(remoteFeaturedPlaylists);
+        });
       });
     }
   }, [code]);


### PR DESCRIPTION
# Description

Hotfix to make auth before make requests in spotify authenticator decorator

---

# What has been done ?

- [ ] Unit test
- [ ] E2E test

# Checklist

- [ ] Domain layer
- [ ] Data layer
- [ ] Infra layer
- [x] Presentation layer
- Main layer
  - [ ] factories
  - [ ] adapters
  - [x] decorators
